### PR TITLE
Allow auto-merge for PRs opened by the Sepia onboarding app

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -26,14 +26,18 @@ jobs:
     # Auto-merge only when:
     #  - validation passed and the PR touches nothing but ssh/*.pub files
     #  - the PR branch lives in this repo (fork PRs get a read-only token)
-    #  - the author is an owner/member/collaborator of the repo
+    #  - the author is an owner/member/collaborator of the repo, or the
+    #    Sepia onboarding GitHub App (apps report author_association NONE)
     needs: validate
     if: >-
       needs.validate.outputs.eligible == 'true' &&
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
-               github.event.pull_request.author_association)
+      (
+        github.event.pull_request.user.login == 'sepia-lab-onboarding-app[bot]' ||
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'),
+                 github.event.pull_request.author_association)
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- PRs #644 and #645 from `sepia-lab-onboarding-app[bot]` passed the `validate` job but `automerge` was skipped, because GitHub Apps have `author_association: NONE` and weren't in the OWNER/MEMBER/COLLABORATOR allowlist.
- Allow that bot login explicitly. The `head.repo.full_name == github.repository` check already guarantees the branch was pushed by something with write access to this repo, so this doesn't widen who can trigger a merge.

## After merging
#644 and #645 need a new `pull_request` event (close/reopen) to pick up the updated workflow. #366 predates the workflow and also needs a close/reopen; #15 has a deleted fork and can't be validated by CI.